### PR TITLE
feat: initialize express app and server

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,4 +1,7 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node'
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,14 @@
       "dependencies": {
         "@tensorflow/tfjs-node": "^4.22.0",
         "chart.js": "^4.4.0",
+        "cors": "^2.8.5",
         "csv-parse": "^5.5.0",
         "express": "^4.18.2",
         "multer": "^1.4.5-lts.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
+        "@types/cors": "^2.8.17",
         "@types/express": "^4.17.21",
         "@types/jest": "^29.5.5",
         "@types/multer": "^2.0.0",
@@ -1616,6 +1618,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
@@ -2945,6 +2957,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,12 @@
   "name": "ann-service",
   "version": "1.0.0",
   "description": "Artificial Neural Network service",
-  "main": "dist/app.js",
+  "main": "dist/server.js",
   "type": "module",
   "scripts": {
-    "dev": "ts-node-dev --respawn --transpile-only src/app.ts",
+    "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
     "build": "tsc",
-    "start": "node dist/app.js",
+    "start": "node dist/server.js",
     "test": "jest",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit"
@@ -18,12 +18,14 @@
     "csv-parse": "^5.5.0",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "cors": "^2.8.5"
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.5",
     "@types/multer": "^2.0.0",
+    "@types/cors": "^2.8.17",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -5,6 +5,6 @@ describe('GET /health', () => {
   it('responds with ok status', async () => {
     const res = await request(app).get('/health');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual({ status: 'ok' });
+    expect(res.body).toEqual({ ok: true });
   });
 });

--- a/src/routes/datasets.ts
+++ b/src/routes/datasets.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/routes/predict.ts
+++ b/src/routes/predict.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/routes/train.ts
+++ b/src/routes/train.ts
@@ -1,0 +1,5 @@
+import { Router } from 'express';
+
+const router = Router();
+
+export default router;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,8 @@
+import app from './app.js';
+
+const PORT = process.env.PORT || 3000;
+
+app.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- set up Express app with CORS, JSON parsing, public static files, and route mounts
- add health check and dashboard placeholders
- create server entry to listen on configurable port

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a425a6b49c833299666beb958dfb05