### PR TITLE
feat: add fs helpers and id generator

### DIFF
--- a/src/lib/fsx.ts
+++ b/src/lib/fsx.ts
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+
+const dirs = ['data', path.join('data', 'uploads'), 'models', 'runs'];
+for (const dir of dirs) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+export async function writeJSON<T>(filePath: string, obj: T): Promise<void> {
+  await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.promises.writeFile(filePath, JSON.stringify(obj, null, 2), 'utf-8');
+}
+
+export async function readJSON<T>(filePath: string): Promise<T> {
+  const data = await fs.promises.readFile(filePath, 'utf-8');
+  return JSON.parse(data) as T;
+}
+
+export async function listJSON<T>(dir: string): Promise<T[]> {
+  const files = await fs.promises.readdir(dir);
+  const results: T[] = [];
+  for (const file of files) {
+    if (file.endsWith('.json')) {
+      const item = await readJSON<T>(path.join(dir, file));
+      results.push(item);
+    }
+  }
+  return results;
+}

--- a/src/lib/ids.ts
+++ b/src/lib/ids.ts
@@ -1,0 +1,7 @@
+import { randomBytes } from 'crypto';
+
+export function newId(): string {
+  const time = Date.now().toString(36);
+  const random = randomBytes(8).toString('hex');
+  return `c${time}${random}`;
+}


### PR DESCRIPTION
## Summary
- add filesystem utilities to safely create runtime directories and handle JSON files
- add CUID-like newId generator using crypto

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a42b1b88148332a0f7f39c66fb86a1