### PR TITLE
feat: add data preprocessing utilities

### DIFF
--- a/src/core/data.test.ts
+++ b/src/core/data.test.ts
@@ -1,0 +1,64 @@
+import {
+  parseCSVToSeries,
+  slidingWindow,
+  trainValTestSplit,
+  fitMinMax,
+} from './data';
+
+describe('parseCSVToSeries', () => {
+  it('parses newline separated values', () => {
+    const csv = '1\n2\n3\n';
+    expect(parseCSVToSeries(csv)).toEqual([1, 2, 3]);
+  });
+});
+
+describe('slidingWindow', () => {
+  it('creates windowed samples', () => {
+    const series = [1, 2, 3, 4, 5];
+    const { x, y } = slidingWindow(series, 3);
+    expect(x).toEqual([
+      [1, 2, 3],
+      [2, 3, 4],
+    ]);
+    expect(y).toEqual([4, 5]);
+  });
+});
+
+describe('trainValTestSplit', () => {
+  it('computes splits with custom ratios', () => {
+    const split = trainValTestSplit(100, { train: 0.6, val: 0.2 });
+    expect(split).toEqual({
+      nTrain: 60,
+      nVal: 20,
+      nTest: 20,
+      train: [0, 60],
+      val: [60, 80],
+      test: [80, 100],
+    });
+  });
+
+  it('uses default ratios', () => {
+    const { nTrain, nVal, nTest } = trainValTestSplit(100);
+    expect({ nTrain, nVal, nTest }).toEqual({
+      nTrain: 30,
+      nVal: 10,
+      nTest: 60,
+    });
+  });
+});
+
+describe('fitMinMax', () => {
+  it('normalizes and denormalizes values', () => {
+    const scaler = fitMinMax([10, 20, 30]);
+    expect(scaler.min).toBe(10);
+    expect(scaler.max).toBe(30);
+    expect(scaler.transform(10)).toBeCloseTo(0);
+    expect(scaler.transform(30)).toBeCloseTo(1);
+
+    const batch = [10, 20, 30];
+    const normalized = scaler.transformBatch(batch);
+    expect(normalized).toEqual([0, 0.5, 1]);
+    const denorm = scaler.inverseBatch(normalized);
+    expect(denorm).toEqual(batch);
+  });
+});

--- a/src/core/data.ts
+++ b/src/core/data.ts
@@ -1,0 +1,116 @@
+import { parse } from 'csv-parse/sync';
+
+/**
+ * Parse a CSV string into a numeric series.
+ *
+ * The CSV is expected to contain a single column of numeric values. Values may
+ * be separated by commas or new lines. Empty lines are ignored.
+ *
+ * @param csv - Raw CSV string.
+ * @returns Array of numeric values parsed from the CSV.
+ */
+export function parseCSVToSeries(csv: string): number[] {
+  const records: string[][] = parse(csv, {
+    columns: false,
+    skip_empty_lines: true,
+    trim: true,
+  });
+  return records.flat().map((v) => Number(v));
+}
+
+/**
+ * Create sliding window samples from a numeric series.
+ *
+ * For a given window size `w` and series `[v0, v1, ... vn]`, this function
+ * returns pairs `x[i] = [v_i, ..., v_{i+w-1}]` and the corresponding next value
+ * `y[i] = v_{i+w}`. The number of samples is `series.length - window`.
+ *
+ * @param series - Input numeric series.
+ * @param window - Size of each window.
+ * @returns Object containing windowed inputs `x` and target outputs `y`.
+ */
+export function slidingWindow(
+  series: number[],
+  window: number,
+): { x: number[][]; y: number[] } {
+  const x: number[][] = [];
+  const y: number[] = [];
+  for (let i = 0; i + window < series.length; i++) {
+    x.push(series.slice(i, i + window));
+    y.push(series[i + window]);
+  }
+  return { x, y };
+}
+
+interface SplitResult {
+  nTrain: number;
+  nVal: number;
+  nTest: number;
+  train: [number, number];
+  val: [number, number];
+  test: [number, number];
+}
+
+/**
+ * Calculate train/validation/test split sizes and index ranges.
+ *
+ * Splits are computed using floor for train and validation sizes; the test set
+ * receives the remaining items. Index ranges are returned as `[start, end)`
+ * half-open intervals suitable for array slicing.
+ *
+ * @param n - Total number of items.
+ * @param ratios - Ratios for train and validation portions. Test ratio is
+ *   implied as the remainder.
+ * @returns Split sizes and index ranges.
+ */
+export function trainValTestSplit(
+  n: number,
+  ratios: { train?: number; val?: number } = { train: 0.3, val: 0.1 },
+): SplitResult {
+  const trainRatio = ratios.train ?? 0.3;
+  const valRatio = ratios.val ?? 0.1;
+  const nTrain = Math.floor(n * trainRatio);
+  const nVal = Math.floor(n * valRatio);
+  const nTest = n - nTrain - nVal;
+  return {
+    nTrain,
+    nVal,
+    nTest,
+    train: [0, nTrain],
+    val: [nTrain, nTrain + nVal],
+    test: [nTrain + nVal, n],
+  };
+}
+
+export interface MinMaxScaler {
+  min: number;
+  max: number;
+  transform(v: number): number;
+  inverse(v: number): number;
+  transformBatch(values: number[]): number[];
+  inverseBatch(values: number[]): number[];
+}
+
+/**
+ * Fit a min-max scaler on the provided series.
+ *
+ * The resulting transformer scales values to the [0, 1] range. For constant
+ * series where `min === max`, the transform outputs `0` and the inverse returns
+ * the constant value.
+ *
+ * @param series - Input numeric series.
+ * @returns An object with scaling parameters and helper functions for
+ *   transforming single values or arrays.
+ */
+export function fitMinMax(series: number[]): MinMaxScaler {
+  const min = Math.min(...series);
+  const max = Math.max(...series);
+  const range = max - min || 1; // avoid division by zero
+
+  const transform = (v: number): number => (v - min) / range;
+  const inverse = (v: number): number => v * range + min;
+  const transformBatch = (values: number[]): number[] => values.map(transform);
+  const inverseBatch = (values: number[]): number[] => values.map(inverse);
+
+  return { min, max, transform, inverse, transformBatch, inverseBatch };
+}


### PR DESCRIPTION
## Summary
- add CSV parsing, sliding window, data splitting, and min-max scaling helpers
- cover data helpers with unit tests

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a42c9906348332a874214f170ab29d