### PR TITLE
Add metrics utilities for error analysis

### DIFF
--- a/src/core/metrics.test.ts
+++ b/src/core/metrics.test.ts
@@ -1,0 +1,54 @@
+import {
+  rms,
+  absoluteErrors,
+  relativeErrorsPct,
+  cumulativeError,
+  computeAllMetrics,
+} from './metrics';
+
+describe('rms', () => {
+  it('computes root mean square error', () => {
+    const yTrue = [1, 2, 3];
+    const yPred = [2, 2, 4];
+    const expected = Math.sqrt((1 ** 2 + 0 ** 2 + 1 ** 2) / 3);
+    expect(rms(yTrue, yPred)).toBeCloseTo(expected);
+  });
+});
+
+describe('absoluteErrors', () => {
+  it('returns absolute errors for each element', () => {
+    const yTrue = [1, 2, 3];
+    const yPred = [2, 2, 4];
+    expect(absoluteErrors(yTrue, yPred)).toEqual([1, 0, 1]);
+  });
+});
+
+describe('relativeErrorsPct', () => {
+  it('computes relative percentage errors and handles zero truth with epsilon', () => {
+    const yTrue = [0, 2];
+    const yPred = [1, 1];
+    const result = relativeErrorsPct(yTrue, yPred);
+    expect(result[0]).toBeCloseTo(1e11);
+    expect(result[1]).toBeCloseTo(50);
+  });
+});
+
+describe('cumulativeError', () => {
+  it('computes mean signed error', () => {
+    const yTrue = [1, 2, 3];
+    const yPred = [2, 2, 4];
+    expect(cumulativeError(yTrue, yPred)).toBeCloseTo(2 / 3);
+  });
+});
+
+describe('computeAllMetrics', () => {
+  it('returns all metrics in a single object', () => {
+    const yTrue = [1, 2, 3];
+    const yPred = [2, 2, 4];
+    const metrics = computeAllMetrics(yTrue, yPred);
+    expect(metrics.rms).toBeCloseTo(rms(yTrue, yPred));
+    expect(metrics.abs).toEqual(absoluteErrors(yTrue, yPred));
+    expect(metrics.relPct).toEqual(relativeErrorsPct(yTrue, yPred));
+    expect(metrics.cumulative).toBeCloseTo(cumulativeError(yTrue, yPred));
+  });
+});

--- a/src/core/metrics.ts
+++ b/src/core/metrics.ts
@@ -1,0 +1,42 @@
+const EPSILON = 1e-9;
+
+function rms(yTrue: number[], yPred: number[]): number {
+  const n = yTrue.length;
+  let sumSq = 0;
+  for (let i = 0; i < n; i++) {
+    const diff = yTrue[i] - yPred[i];
+    sumSq += diff * diff;
+  }
+  return Math.sqrt(sumSq / n);
+}
+
+function absoluteErrors(yTrue: number[], yPred: number[]): number[] {
+  return yTrue.map((v, i) => Math.abs(v - yPred[i]));
+}
+
+function relativeErrorsPct(yTrue: number[], yPred: number[]): number[] {
+  return yTrue.map((v, i) => {
+    const denom = Math.abs(v) || EPSILON;
+    return (Math.abs(v - yPred[i]) / denom) * 100;
+  });
+}
+
+function cumulativeError(yTrue: number[], yPred: number[]): number {
+  const n = yTrue.length;
+  let sum = 0;
+  for (let i = 0; i < n; i++) {
+    sum += yPred[i] - yTrue[i];
+  }
+  return sum / n;
+}
+
+export function computeAllMetrics(yTrue: number[], yPred: number[]) {
+  return {
+    rms: rms(yTrue, yPred),
+    abs: absoluteErrors(yTrue, yPred),
+    relPct: relativeErrorsPct(yTrue, yPred),
+    cumulative: cumulativeError(yTrue, yPred),
+  };
+}
+
+export { rms, absoluteErrors, relativeErrorsPct, cumulativeError };


### PR DESCRIPTION
## Summary
- implement RMS, absolute error, relative percentage error, and cumulative error calculations
- expose computeAllMetrics helper and unit tests verifying zero-handling

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a42fd0b9048332943eec17b59226fa