### PR TITLE
feat: add model utilities

### DIFF
--- a/src/core/model.test.ts
+++ b/src/core/model.test.ts
@@ -1,0 +1,21 @@
+import { buildMLP, trainModel } from './model';
+
+describe('buildMLP', () => {
+  it('creates a model with two layers', () => {
+    const model = buildMLP(3);
+    expect(model.layers).toHaveLength(2);
+    model.dispose();
+  });
+});
+
+describe('trainModel', () => {
+  it('trains and returns predictions', async () => {
+    const series = Array.from({ length: 10 }, (_, i) => i + 1);
+    const result = await trainModel(series, 3, 1, { train: 0.5, val: 0.2 });
+    expect(result.yPredTest.length).toBe(result.yTrueTest.length);
+    expect(result.indexes.endTest - result.indexes.startTest).toBe(
+      result.yTrueTest.length,
+    );
+    result.model.dispose();
+  });
+});

--- a/src/core/model.ts
+++ b/src/core/model.ts
@@ -1,0 +1,65 @@
+import * as tf from '@tensorflow/tfjs-node';
+import { slidingWindow, trainValTestSplit } from './data';
+
+export function buildMLP(inputSize: number, hidden = 32): tf.Sequential {
+  const model = tf.sequential();
+  model.add(
+    tf.layers.dense({
+      units: hidden,
+      activation: 'relu',
+      inputShape: [inputSize],
+    }),
+  );
+  model.add(tf.layers.dense({ units: 1 }));
+  model.compile({ optimizer: tf.train.adam(), loss: 'meanSquaredError' });
+  return model;
+}
+
+export async function trainModel(
+  series: number[],
+  window = 5,
+  epochs = 50,
+  ratios: { train?: number; val?: number } = { train: 0.3, val: 0.1 },
+): Promise<{
+  model: tf.Sequential;
+  yTrueTest: number[];
+  yPredTest: number[];
+  indexes: { startTest: number; endTest: number };
+}> {
+  const { x, y } = slidingWindow(series, window);
+  const split = trainValTestSplit(x.length, ratios);
+
+  const [startTrain, endTrain] = split.train;
+  const [startVal, endVal] = split.val;
+  const [startTest, endTest] = split.test;
+
+  const xTrain = tf.tensor2d(x.slice(startTrain, endTrain));
+  const yTrain = tf.tensor1d(y.slice(startTrain, endTrain));
+  const xVal = tf.tensor2d(x.slice(startVal, endVal));
+  const yVal = tf.tensor1d(y.slice(startVal, endVal));
+  const xTest = tf.tensor2d(x.slice(startTest, endTest));
+  const yTrueTest = y.slice(startTest, endTest);
+
+  const model = buildMLP(window, 32);
+
+  await model.fit(xTrain, yTrain, {
+    epochs,
+    validationData: [xVal, yVal],
+    verbose: 0,
+  });
+
+  const yPredTensor = model.predict(xTest) as tf.Tensor;
+  const yPredTest = Array.from(await yPredTensor.data());
+
+  tf.dispose([xTrain, yTrain, xVal, yVal, xTest, yPredTensor]);
+
+  return { model, yTrueTest, yPredTest, indexes: { startTest, endTest } };
+}
+
+export async function saveModel(model: tf.LayersModel, runId: string) {
+  await model.save(`file://models/${runId}`);
+}
+
+export async function loadModel(runId: string): Promise<tf.LayersModel> {
+  return tf.loadLayersModel(`file://models/${runId}/model.json`);
+}


### PR DESCRIPTION
## Summary
- add model utilities for building, training, saving and loading TensorFlow.js models
- include tests for basic model functionality

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a43834213c83329fefc2e17635ecbb