### PR TITLE
feat: track training runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 /coverage
 /models
 /data/uploads
+/runs

--- a/src/core/runs.test.ts
+++ b/src/core/runs.test.ts
@@ -1,0 +1,53 @@
+import fs from 'fs';
+import { createRun, getRun, updateRun, listRuns } from './runs';
+
+describe('runs', () => {
+  beforeEach(async () => {
+    await fs.promises.rm('runs', { recursive: true, force: true });
+  });
+
+  it('creates and retrieves a run', async () => {
+    const run = await createRun({
+      window: 3,
+      epochs: 5,
+      ratios: { train: 0.6, val: 0.2 },
+      datasetName: 'test.csv',
+    });
+    const loaded = await getRun(run.id);
+    expect(loaded).toEqual(run);
+  });
+
+  it('updates a run with new data', async () => {
+    const run = await createRun({
+      window: 3,
+      epochs: 5,
+      ratios: { train: 0.6 },
+      datasetName: 'test.csv',
+    });
+    const updated = await updateRun(run.id, {
+      metrics: { rms: 1 },
+      modelPath: 'models/path',
+    });
+    expect(updated.metrics).toEqual({ rms: 1 });
+    expect(updated.modelPath).toBe('models/path');
+  });
+
+  it('lists runs sorted by creation date desc', async () => {
+    const run1 = await createRun({
+      window: 3,
+      epochs: 5,
+      ratios: {},
+      datasetName: 'a',
+    });
+    await new Promise((r) => setTimeout(r, 5));
+    const run2 = await createRun({
+      window: 3,
+      epochs: 5,
+      ratios: {},
+      datasetName: 'b',
+    });
+    const runs = await listRuns();
+    expect(runs.map((r) => r.id)).toEqual([run2.id, run1.id]);
+  });
+});
+

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -1,0 +1,68 @@
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { writeJSON, readJSON, listJSON } from '../lib/fsx';
+
+export interface RunMeta {
+  window: number;
+  epochs: number;
+  ratios: { train?: number; val?: number };
+  datasetName: string;
+  metrics?: unknown;
+  modelPath?: string;
+}
+
+export interface Run
+  extends Omit<RunMeta, 'metrics' | 'modelPath'> {
+  id: string;
+  createdAt: string;
+  metrics: unknown | null;
+  modelPath: string | null;
+}
+
+export async function createRun(meta: RunMeta): Promise<Run> {
+  const id = randomUUID();
+  const createdAt = new Date().toISOString();
+  const run: Run = {
+    id,
+    createdAt,
+    window: meta.window,
+    epochs: meta.epochs,
+    ratios: meta.ratios,
+    datasetName: meta.datasetName,
+    metrics: meta.metrics ?? null,
+    modelPath: meta.modelPath ?? null,
+  };
+  await writeJSON(path.join('runs', `${id}.json`), run);
+  return run;
+}
+
+export async function updateRun(
+  runId: string,
+  patch: Partial<RunMeta>,
+): Promise<Run> {
+  const filePath = path.join('runs', `${runId}.json`);
+  const run = await readJSON<Run>(filePath);
+  const updated: Run = { ...run, ...patch };
+  await writeJSON(filePath, updated);
+  return updated;
+}
+
+export async function getRun(runId: string): Promise<Run | undefined> {
+  try {
+    return await readJSON<Run>(path.join('runs', `${runId}.json`));
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return undefined;
+    }
+    throw err;
+  }
+}
+
+export async function listRuns(): Promise<Run[]> {
+  const runs = await listJSON<Run>('runs');
+  return runs.sort(
+    (a, b) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+  );
+}
+


### PR DESCRIPTION
## Summary
- add run tracking utilities to create, update, retrieve and list runs
- ignore generated run records
- test run persistence helpers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a439d87828833299fa590956336a05