### PR TITLE
Add prediction and run retrieval endpoints

### DIFF
--- a/src/routes/predict.ts
+++ b/src/routes/predict.ts
@@ -1,5 +1,54 @@
 import { Router } from 'express';
+import * as tf from '@tensorflow/tfjs-node';
+import { z } from 'zod';
+
+import { loadModel } from '../core/model.js';
+import { getRun } from '../core/runs.js';
 
 const router = Router();
+
+// Schema for validating prediction requests
+const PredictSchema = z.object({
+  runId: z.string(),
+  context: z.array(z.number()),
+});
+
+router.post('/', async (req, res) => {
+  const parsed = PredictSchema.safeParse(req.body);
+  if (!parsed.success) {
+    res.status(400).json({ error: parsed.error.message });
+    return;
+  }
+
+  const { runId, context } = parsed.data;
+
+  const run = await getRun(runId);
+  if (!run) {
+    res.status(404).json({ error: 'Run not found' });
+    return;
+  }
+
+  if (context.length !== run.window) {
+    res.status(400).json({ error: `Context length must be ${run.window}` });
+    return;
+  }
+
+  let model;
+  try {
+    model = await loadModel(runId);
+  } catch {
+    res.status(404).json({ error: 'Model not found' });
+    return;
+  }
+
+  const input = tf.tensor2d([context]);
+  const output = model.predict(input) as tf.Tensor;
+  const [next] = Array.from(await output.data());
+
+  tf.dispose([input, output]);
+  model.dispose();
+
+  res.json({ next });
+});
 
 export default router;

--- a/src/routes/runs.ts
+++ b/src/routes/runs.ts
@@ -1,5 +1,46 @@
 import { Router } from 'express';
 
+import { listRuns, getRun } from '../core/runs.js';
+
 const router = Router();
+
+// Get latest 20 runs with basic info
+router.get('/', async (_req, res) => {
+  const runs = await listRuns();
+  const latest = runs.slice(0, 20).map((r) => {
+    const metrics = r.metrics as { rms?: number } | null;
+    return {
+      id: r.id,
+      createdAt: r.createdAt,
+      datasetName: r.datasetName,
+      rms: metrics?.rms ?? null,
+    };
+  });
+  res.json(latest);
+});
+
+// Get full run info
+router.get('/:id', async (req, res) => {
+  const run = await getRun(req.params.id);
+  if (!run) {
+    res.status(404).json({ error: 'Run not found' });
+    return;
+  }
+  res.json(run);
+});
+
+// Get only metrics for a run
+router.get('/:id/metrics', async (req, res) => {
+  const run = await getRun(req.params.id);
+  if (!run) {
+    res.status(404).json({ error: 'Run not found' });
+    return;
+  }
+  if (!run.metrics) {
+    res.status(404).json({ error: 'Metrics not found' });
+    return;
+  }
+  res.json(run.metrics);
+});
 
 export default router;


### PR DESCRIPTION
## Summary
- implement POST /api/predict to load a trained model and forecast next value from context
- expose run history API with listing, details, and metrics endpoints

## Testing
- `npm test`
- `npx eslint src/routes/predict.ts src/routes/runs.ts && echo 'lint ok'`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a45544cfb88332b0fe83ed78c61549