### PR TITLE
Configure ts-jest and add sine test fixtures

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,7 +1,0 @@
-module.exports = {
-  preset: 'ts-jest/presets/default-esm',
-  testEnvironment: 'node',
-  moduleNameMapper: {
-    '^(\\.{1,2}/.*)\\.js$': '$1'
-  }
-};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,12 @@
+import type { JestConfigWithTsJest } from 'ts-jest';
+
+const config: JestConfigWithTsJest = {
+  preset: 'ts-jest/presets/default-esm',
+  extensionsToTreatAsEsm: ['.ts'],
+  testEnvironment: 'node',
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1'
+  }
+};
+
+export default config;

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -1,0 +1,31 @@
+/**
+ * Utility fixtures for small sine wave sequences used in tests.
+ */
+
+/** Generate a clean sine sequence of given length. */
+export function generateSineSequence(length: number): number[] {
+  return Array.from({ length }, (_, i) => Math.sin((2 * Math.PI * i) / length));
+}
+
+/**
+ * Deterministic pseudo random number generator (LCG) for reproducible noise.
+ */
+function prng(seed: number): () => number {
+  let value = seed % 2147483647;
+  return () => {
+    value = (value * 16807) % 2147483647;
+    return (value - 1) / 2147483646;
+  };
+}
+
+/**
+ * Add tiny deterministic noise to a sequence.
+ */
+export function addTinyNoise(seq: number[], seed = 1, amplitude = 0.01): number[] {
+  const rand = prng(seed);
+  return seq.map(v => v + (rand() * 2 - 1) * amplitude);
+}
+
+// Pre-generated fixtures
+export const cleanSine = generateSineSequence(16);
+export const noisySine = addTinyNoise(cleanSine, 42);


### PR DESCRIPTION
## Summary
- replace CommonJS jest config with TypeScript version using ts-jest and node environment
- add deterministic sine wave fixtures for future tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a457b2b4988332be7a91b0e1c189a2