### PR TITLE
Add unit tests for data utilities and metrics

### DIFF
--- a/tests/data.test.ts
+++ b/tests/data.test.ts
@@ -1,0 +1,52 @@
+import { slidingWindow, trainValTestSplit } from '../src/core/data';
+
+describe('slidingWindow', () => {
+  it('returns correct number of samples and boundaries', () => {
+    const series = [1, 2, 3, 4, 5];
+    const window = 2;
+    const { x, y } = slidingWindow(series, window);
+
+    // total number of samples should be length - window
+    expect(x).toHaveLength(series.length - window);
+    expect(y).toHaveLength(series.length - window);
+
+    // each window should have the correct size
+    expect(x.every((w) => w.length === window)).toBe(true);
+
+    // boundary windows
+    expect(x[0]).toEqual([1, 2]);
+    expect(x[x.length - 1]).toEqual([3, 4]);
+    expect(y).toEqual([3, 4, 5]);
+  });
+
+  it('returns empty arrays when window exceeds or equals series length', () => {
+    const series = [1, 2, 3];
+    expect(slidingWindow(series, 3)).toEqual({ x: [], y: [] });
+    expect(slidingWindow(series, 4)).toEqual({ x: [], y: [] });
+  });
+});
+
+describe('trainValTestSplit', () => {
+  it('computes split sizes and ranges', () => {
+    const split = trainValTestSplit(10, { train: 0.5, val: 0.3 });
+    expect(split).toEqual({
+      nTrain: 5,
+      nVal: 3,
+      nTest: 2,
+      train: [0, 5],
+      val: [5, 8],
+      test: [8, 10],
+    });
+  });
+
+  it('uses default ratios when none provided', () => {
+    const split = trainValTestSplit(10);
+    expect(split.nTrain + split.nVal + split.nTest).toBe(10);
+    expect(split.train[0]).toBe(0);
+    expect(split.train[1]).toBe(split.nTrain);
+    expect(split.val[0]).toBe(split.nTrain);
+    expect(split.val[1]).toBe(split.nTrain + split.nVal);
+    expect(split.test[0]).toBe(split.nTrain + split.nVal);
+    expect(split.test[1]).toBe(10);
+  });
+});

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,0 +1,31 @@
+import { rms, absoluteErrors, relativeErrorsPct, cumulativeError } from '../src/core/metrics';
+
+describe('metrics sanity checks', () => {
+  it('computes rms correctly for tiny arrays', () => {
+    const yTrue = [1, 2, 3];
+    const yPred = [2, 1, 3];
+    const expected = Math.sqrt((1 ** 2 + 1 ** 2 + 0 ** 2) / yTrue.length);
+    expect(rms(yTrue, yPred)).toBeCloseTo(expected);
+  });
+
+  it('computes absolute errors', () => {
+    const yTrue = [1, 2, 3];
+    const yPred = [2, 1, 3];
+    expect(absoluteErrors(yTrue, yPred)).toEqual([1, 1, 0]);
+  });
+
+  it('computes relative error percent and handles zero target', () => {
+    const yTrue = [0, 2];
+    const yPred = [1, 1];
+    const result = relativeErrorsPct(yTrue, yPred);
+    expect(result[0]).toBeCloseTo(1e11);
+    expect(result[1]).toBeCloseTo(50);
+  });
+
+  it('computes cumulative error', () => {
+    const yTrue = [1, 2, 3];
+    const yPred = [2, 1, 3];
+    const expected = ((2 - 1) + (1 - 2) + (3 - 3)) / yTrue.length;
+    expect(cumulativeError(yTrue, yPred)).toBeCloseTo(expected);
+  });
+});


### PR DESCRIPTION
## Summary
- add comprehensive slidingWindow tests for sample sizes and boundaries
- cover train/val/test splitting defaults and ratios
- validate core metrics with tiny arrays including zero targets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a45a09dd248332b9025d930af6d0e1