### PR TITLE
Centralize training config and speed up tests

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,5 @@
+export const isTest = process.env.NODE_ENV === 'test';
+
+export const DEFAULT_WINDOW = 5;
+export const DEFAULT_EPOCHS = isTest ? 1 : 50;
+export const MAX_DATASET_LENGTH = isTest ? 100 : Infinity;

--- a/src/core/model.test.ts
+++ b/src/core/model.test.ts
@@ -1,4 +1,5 @@
 import { buildMLP, trainModel } from './model';
+import { DEFAULT_EPOCHS } from '../config.js';
 
 describe('buildMLP', () => {
   it('creates a model with two layers', () => {
@@ -11,7 +12,10 @@ describe('buildMLP', () => {
 describe('trainModel', () => {
   it('trains and returns predictions', async () => {
     const series = Array.from({ length: 10 }, (_, i) => i + 1);
-    const result = await trainModel(series, 3, 1, { train: 0.5, val: 0.2 });
+    const result = await trainModel(series, 3, DEFAULT_EPOCHS, {
+      train: 0.5,
+      val: 0.2,
+    });
     expect(result.yPredTest.length).toBe(result.yTrueTest.length);
     expect(result.indexes.endTest - result.indexes.startTest).toBe(
       result.yTrueTest.length,

--- a/src/core/model.ts
+++ b/src/core/model.ts
@@ -1,5 +1,6 @@
 import * as tf from '@tensorflow/tfjs-node';
 import { slidingWindow, trainValTestSplit } from './data';
+import { DEFAULT_EPOCHS, DEFAULT_WINDOW } from '../config.js';
 
 export function buildMLP(inputSize: number, hidden = 32): tf.Sequential {
   const model = tf.sequential();
@@ -17,8 +18,8 @@ export function buildMLP(inputSize: number, hidden = 32): tf.Sequential {
 
 export async function trainModel(
   series: number[],
-  window = 5,
-  epochs = 50,
+  window = DEFAULT_WINDOW,
+  epochs = DEFAULT_EPOCHS,
   ratios: { train?: number; val?: number } = { train: 0.3, val: 0.1 },
 ): Promise<{
   model: tf.Sequential;

--- a/src/routes/datasets.ts
+++ b/src/routes/datasets.ts
@@ -5,6 +5,7 @@ import path from 'path';
 
 import { newId } from '../lib/ids.js';
 import { parseCSVToSeries } from '../core/data.js';
+import { MAX_DATASET_LENGTH } from '../config.js';
 
 const router = Router();
 
@@ -34,6 +35,9 @@ router.post('/upload', upload.single('file'), async (req, res) => {
   if (series.some((v) => Number.isNaN(v))) {
     res.status(400).json({ error: 'CSV must contain only numeric values' });
     return;
+  }
+  if (series.length > MAX_DATASET_LENGTH) {
+    series = series.slice(0, MAX_DATASET_LENGTH);
   }
 
   const datasetId = newId();
@@ -114,11 +118,12 @@ router.post('/generate', async (req, res) => {
     return;
   }
 
+  const cappedLength = Math.min(length, MAX_DATASET_LENGTH);
   let data: number[];
   if (kind === 'sine') {
-    data = generateSine(length, noise ?? 0);
+    data = generateSine(cappedLength, noise ?? 0);
   } else if (kind === 'duffing') {
-    data = generateDuffing(length);
+    data = generateDuffing(cappedLength);
   } else {
     res.status(400).json({ error: 'Unknown kind' });
     return;


### PR DESCRIPTION
## Summary
- centralize default window, epochs, and dataset limits in `src/config.ts`
- use shared defaults in training and dataset routes with test-aware dataset cap
- adjust tests to use config defaults and run with minimal epochs for faster CI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5764addd08332b98cd3e5d1da1892