### PR TITLE
chore: enforce linting and tests on pre-commit

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,7 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
   parserOptions: {
-    project: './tsconfig.json',
+    project: './tsconfig.eslint.json',
     sourceType: 'module'
   },
   plugins: ['@typescript-eslint', 'prettier'],

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+npm run lint && npm test

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -5,8 +5,8 @@ const config: JestConfigWithTsJest = {
   extensionsToTreatAsEsm: ['.ts'],
   testEnvironment: 'node',
   moduleNameMapper: {
-    '^(\\.{1,2}/.*)\\.js$': '$1'
-  }
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-prettier": "^5.1.3",
+        "husky": "^9.1.7",
         "jest": "^29.7.0",
         "prettier": "^3.2.5",
         "supertest": "^6.3.3",
@@ -4360,6 +4361,22 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -9,29 +9,31 @@
     "build": "tsc",
     "start": "node dist/server.js",
     "test": "jest",
-    "lint": "eslint . --ext .ts",
-    "typecheck": "tsc --noEmit"
-  },
+      "lint": "eslint . --ext .ts",
+      "typecheck": "tsc --noEmit",
+      "prepare": "husky install"
+    },
   "dependencies": {
     "@tensorflow/tfjs-node": "^4.22.0",
     "chart.js": "^4.4.0",
+    "cors": "^2.8.5",
     "csv-parse": "^5.5.0",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
-    "zod": "^3.23.8",
-    "cors": "^2.8.5"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/jest": "^29.5.5",
     "@types/multer": "^2.0.0",
-    "@types/cors": "^2.8.17",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^7.7.1",
     "@typescript-eslint/parser": "^7.7.1",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "husky": "^9.1.7",
     "jest": "^29.7.0",
     "prettier": "^3.2.5",
     "supertest": "^6.3.3",

--- a/src/core/runs.test.ts
+++ b/src/core/runs.test.ts
@@ -50,4 +50,3 @@ describe('runs', () => {
     expect(runs.map((r) => r.id)).toEqual([run2.id, run1.id]);
   });
 });
-

--- a/src/core/runs.ts
+++ b/src/core/runs.ts
@@ -11,8 +11,7 @@ export interface RunMeta {
   modelPath?: string;
 }
 
-export interface Run
-  extends Omit<RunMeta, 'metrics' | 'modelPath'> {
+export interface Run extends Omit<RunMeta, 'metrics' | 'modelPath'> {
   id: string;
   createdAt: string;
   metrics: unknown | null;
@@ -61,8 +60,6 @@ export async function getRun(runId: string): Promise<Run | undefined> {
 export async function listRuns(): Promise<Run[]> {
   const runs = await listJSON<Run>('runs');
   return runs.sort(
-    (a, b) =>
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
   );
 }
-

--- a/src/routes/datasets.ts
+++ b/src/routes/datasets.ts
@@ -91,7 +91,10 @@ function generateDuffing(length: number): number[] {
   for (let i = 0; i < limit; i++) {
     const dx = y;
     const dy =
-      -delta * y - alpha * x - beta * x * x * x + gamma * Math.cos(omega * i * dt);
+      -delta * y -
+      alpha * x -
+      beta * x * x * x +
+      gamma * Math.cos(omega * i * dt);
     x += dx * dt;
     y += dy * dt;
     series.push(x);
@@ -136,9 +139,9 @@ router.post('/generate', async (req, res) => {
   res.json({ datasetId, path: filePath });
 });
 
-async function listCsvFiles(dir: string): Promise<
-  { datasetId: string; path: string; length: number }[]
-> {
+async function listCsvFiles(
+  dir: string,
+): Promise<{ datasetId: string; path: string; length: number }[]> {
   const entries = await fs.promises.readdir(dir, { withFileTypes: true });
   const items: { datasetId: string; path: string; length: number }[] = [];
   for (const entry of entries) {

--- a/tests/fixtures.ts
+++ b/tests/fixtures.ts
@@ -21,9 +21,13 @@ function prng(seed: number): () => number {
 /**
  * Add tiny deterministic noise to a sequence.
  */
-export function addTinyNoise(seq: number[], seed = 1, amplitude = 0.01): number[] {
+export function addTinyNoise(
+  seq: number[],
+  seed = 1,
+  amplitude = 0.01,
+): number[] {
   const rand = prng(seed);
-  return seq.map(v => v + (rand() * 2 - 1) * amplitude);
+  return seq.map((v) => v + (rand() * 2 - 1) * amplitude);
 }
 
 // Pre-generated fixtures

--- a/tests/metrics.test.ts
+++ b/tests/metrics.test.ts
@@ -1,4 +1,9 @@
-import { rms, absoluteErrors, relativeErrorsPct, cumulativeError } from '../src/core/metrics';
+import {
+  rms,
+  absoluteErrors,
+  relativeErrorsPct,
+  cumulativeError,
+} from '../src/core/metrics';
 
 describe('metrics sanity checks', () => {
   it('computes rms correctly for tiny arrays', () => {
@@ -25,7 +30,7 @@ describe('metrics sanity checks', () => {
   it('computes cumulative error', () => {
     const yTrue = [1, 2, 3];
     const yPred = [2, 1, 3];
-    const expected = ((2 - 1) + (1 - 2) + (3 - 3)) / yTrue.length;
+    const expected = (2 - 1 + (1 - 2) + (3 - 3)) / yTrue.length;
     expect(cumulativeError(yTrue, yPred)).toBeCloseTo(expected);
   });
 });

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src", "tests", "jest.config.ts"]
+}


### PR DESCRIPTION
## Summary
- run lint and tests through Husky pre-commit hook
- add prepare script for Husky install and expose typecheck script
- fix lint issues in datasets route and tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a57e975bf48332a9103209a6d4eea7